### PR TITLE
Fixed the Complement Syntax from ^[abc] to [^abc]

### DIFF
--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Complement.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Complement.java
@@ -9,8 +9,8 @@ import com.github.sgreben.regex_builder.CharClass;
 public class Complement extends Unary {
 	public Complement(CharClass child) { super(child); }
 	public void compile(java.util.List<TOKEN> output) {
-		output.add(new CARET());
 		output.add(new START_CHAR_CLASS());
+		output.add(new CARET());
 		for(CharClass child : children()) {
 			child.compile(output);
 		}


### PR DESCRIPTION
Looks like there was a bug in your library, so I fixed it.
See documentation of Regex here: https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html