### PR TITLE
Added NoneOf CharClass and Tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,11 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+	<dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.1</version>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/src/main/java/com/github/sgreben/regex_builder/CharClass.java
+++ b/src/main/java/com/github/sgreben/regex_builder/CharClass.java
@@ -108,6 +108,10 @@ public abstract class CharClass {
         return new OneOf(chars);
     }
 
+    public static CharClass noneOf(String chars) {
+        return new NoneOf(chars);
+    }
+
     private static CharClass[] convertStrings(Object[] os) {
         CharClass[] charClasses = new CharClass[os.length];
         for (int i = 0; i < os.length; ++i) {

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NoneOf.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NoneOf.java
@@ -1,0 +1,20 @@
+package com.github.sgreben.regex_builder.charclass;
+
+import com.github.sgreben.regex_builder.tokens.CARET;
+import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
+import com.github.sgreben.regex_builder.tokens.RAW;
+import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
+import com.github.sgreben.regex_builder.tokens.TOKEN;
+
+public class NoneOf extends Nullary {
+	private final String chars;
+	public NoneOf(String chars) {
+		this.chars = chars;
+	}
+	public void compile(java.util.List<TOKEN> output) {
+		output.add(new START_CHAR_CLASS());
+		output.add(new CARET());
+		output.add(new RAW(chars));
+		output.add(new END_CHAR_CLASS());
+	}
+}

--- a/src/main/java/com/github/sgreben/regex_builder/hamcrest/MatchesPattern.java
+++ b/src/main/java/com/github/sgreben/regex_builder/hamcrest/MatchesPattern.java
@@ -1,0 +1,35 @@
+package com.github.sgreben.regex_builder.hamcrest;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import com.github.sgreben.regex_builder.Pattern;
+
+
+
+public class MatchesPattern extends TypeSafeMatcher<String> {
+    private final Pattern pattern;
+
+    public MatchesPattern(Pattern pattern) {
+        this.pattern = pattern;
+    }
+
+    @Override
+    protected boolean matchesSafely(String item) {
+        return pattern.matcher(item).matches();
+    }
+
+    @Override
+    public void describeTo(Description description) {
+        description.appendText("a string matching the pattern '" + pattern + "'");
+    }
+
+    /**
+     * Creates a matcher of {@link java.lang.String} that matches when the examined string
+     * exactly matches the given {@link com.github.sgreben.regex_builder.Pattern}.
+     */
+    public static Matcher<String> matchesPattern(Pattern pattern) {
+        return new MatchesPattern(pattern);
+    }
+}

--- a/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
+++ b/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
@@ -1,0 +1,35 @@
+package com.github.sgreben.regex_builder;
+
+import static org.junit.Assert.assertThat;
+
+import org.junit.Test;
+
+import static com.github.sgreben.regex_builder.hamcrest.MatchesPattern.*;
+import static com.github.sgreben.regex_builder.Re.*;
+import static com.github.sgreben.regex_builder.CharClass.*;
+
+import static org.hamcrest.CoreMatchers.*;
+
+public class CharClassTest {
+
+	@Test
+	public void testOneOf() throws Exception {
+		assertCharClassMatch(oneOf("abc"), "abc");
+		assertCharClassMismatch(oneOf("def"), "abc");
+	}
+
+	@Test
+	public void testNoneOf() throws Exception {
+		assertCharClassMatch(noneOf("def"), "abc");
+		assertCharClassMismatch(noneOf("abc"), "abc");
+	}
+
+	private void assertCharClassMatch(CharClass charClass, String example) {
+		assertThat(example, matchesPattern(Pattern.compile(repeat(charClass))));
+	}
+
+	private void assertCharClassMismatch(CharClass charClass, String example) {
+		assertThat(example, not(matchesPattern(Pattern.compile(repeat(charClass)))));
+	}
+
+}

--- a/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
+++ b/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
@@ -2,6 +2,7 @@ package com.github.sgreben.regex_builder;
 
 import static org.junit.Assert.assertThat;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.github.sgreben.regex_builder.hamcrest.MatchesPattern.*;
@@ -11,6 +12,29 @@ import static com.github.sgreben.regex_builder.CharClass.*;
 import static org.hamcrest.CoreMatchers.*;
 
 public class CharClassTest {
+
+	@Test
+	public void testHexDigit() throws Exception {
+		assertCharClassMatch(hexDigit(), "0123456789");
+		assertCharClassMatch(hexDigit(), "abcdef");
+		assertCharClassMatch(hexDigit(), "ABCDEF");
+
+		assertCharClassMismatch(hexDigit(), "G");
+		assertCharClassMismatch(hexDigit(), "[");
+		assertCharClassMismatch(hexDigit(), "]");
+	}
+
+	@Ignore
+	@Test
+	public void testNonHexDigit() throws Exception {
+		assertCharClassMismatch(nonHexDigit(), "0123456789");
+		assertCharClassMismatch(nonHexDigit(), "abcdef");
+		assertCharClassMatch(nonHexDigit(), "ABCDEF");
+
+		assertCharClassMatch(nonHexDigit(), "G");
+		assertCharClassMatch(nonHexDigit(), "[");
+		assertCharClassMatch(nonHexDigit(), "]");
+	}
 
 	@Test
 	public void testOneOf() throws Exception {


### PR DESCRIPTION
As said in #5 i wanted to add NoneOf as a workaround while Complement is not working. I would consider keeping it even after the fix though. Also please take a look at the Hamcrest Matcher I added to support the tests. I would like it public to make this library easier to use in Unit Tests.