### PR TITLE
Fix complement, support pattern flags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.project
 /.classpath
 /.settings
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 /settings.xml
 /gpg-params
 /gpg-home
+/.project
+/.classpath
+/.settings

--- a/README.md
+++ b/README.md
@@ -290,12 +290,12 @@ public static boolean sameIP(String twoLogs) {
 | range(f1, t1, ..., fN, tN)    | [f1-t1f2-t2...fN-tN]     |
 | oneOf("abcde")                | [abcde]                  |
 | union(class1, ..., classN)    | [[class1]...[classN]]    |
-| complement(class1)            | [\^[class1]]             |
+| complement(class1)            | [\^class1]               |
 | anyChar()                     | .                        |
 | digit()                       | \d                       |
 | nonDigit()                    | \D                       |
 | hexDigit()                    | [a-fA-F0-9]              |
-| nonHexDigit()                 | [\^[a-fA-F0-9]]          |
+| nonHexDigit()                 | [\^a-fA-F0-9]            |
 | wordChar()                    | \w                       |
 | nonWordChar()                 | \W                       |
 | wordBoundary()                | \b                       |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ There's a [discussion](https://www.reddit.com/r/java/comments/4tyk90/github_sgre
 <dependency>
   <groupId>com.github.sgreben</groupId>
   <artifactId>regex-builder</artifactId>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -254,7 +254,7 @@ public static boolean sameIP(String twoLogs) {
 ### Expression builder
 
 | Builder method              | `java.util.regex` syntax |
-|-----------------------------|--------------------------|
+| --------------------------- | ------------------------ |
 | repeat(e, N)                | e{N}                     |
 | repeat(e)                   | e*                       |
 | repeat(e).possessive()      | e*+                      |
@@ -284,25 +284,25 @@ public static boolean sameIP(String twoLogs) {
 
 ### CharClass builder
 
-| Builder method                        | `java.util.regex` syntax |
-|---------------------------------------|--------------------------|
-| range(from, to)             | [from-to]                |
-| range(f1, t1, ..., fN, tN)  | [f1-t1f2-t2...fN-tN]     |
-| oneOf("abcde")              | [abcde]                  |
-| union(class1, ..., classN)  | [[class1]...[classN]]    |
-| complement(class1)          | [\^[class1]]              |
-| anyChar()                   | .                        |
-| digit()                     | \d                       |
-| nonDigit()                  | \D                       |
-| hexDigit()                  | [a-fA-F0-9]              |
-| nonHexDigit()               | [\^[a-fA-F0-9]]           |
-| wordChar()                  | \w                       |
-| nonWordChar()               | \W                       |
-| wordBoundary()              | \b                       |
-| nonWordBoundary()           | \B                       |
-| whitespaceChar()            | \s                       |
-| nonWhitespaceChar()         | \S                       |
-| verticalWhitespaceChar()    | \v                       |
-| nonVerticalWhitespaceChar() | \V                       |
-| horizontalWhitespaceChar()  | \h                       |
-| nonHorizontalWhitespaceChar()| \H                      |
+| Builder method                | `java.util.regex` syntax |
+| ----------------------------- | ------------------------ |
+| range(from, to)               | [from-to]                |
+| range(f1, t1, ..., fN, tN)    | [f1-t1f2-t2...fN-tN]     |
+| oneOf("abcde")                | [abcde]                  |
+| union(class1, ..., classN)    | [[class1]...[classN]]    |
+| complement(class1)            | [\^[class1]]             |
+| anyChar()                     | .                        |
+| digit()                       | \d                       |
+| nonDigit()                    | \D                       |
+| hexDigit()                    | [a-fA-F0-9]              |
+| nonHexDigit()                 | [\^[a-fA-F0-9]]          |
+| wordChar()                    | \w                       |
+| nonWordChar()                 | \W                       |
+| wordBoundary()                | \b                       |
+| nonWordBoundary()             | \B                       |
+| whitespaceChar()              | \s                       |
+| nonWhitespaceChar()           | \S                       |
+| verticalWhitespaceChar()      | \v                       |
+| nonVerticalWhitespaceChar()   | \V                       |
+| horizontalWhitespaceChar()    | \h                       |
+| nonHorizontalWhitespaceChar() | \H                       |

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.github.sgreben</groupId>
   <artifactId>regex-builder</artifactId>
   <packaging>jar</packaging>
-  <version>1.0.2</version>
+  <version>1.1.0</version>
   <name>${project.groupId}:${project.artifactId}</name>
   <description>Construct regular expressions as pure Java code.</description>
   <url>https://github.com/sgreben/regex-builder/</url>

--- a/src/main/java/com/github/sgreben/regex_builder/CaptureGroup.java
+++ b/src/main/java/com/github/sgreben/regex_builder/CaptureGroup.java
@@ -8,7 +8,7 @@ import com.github.sgreben.regex_builder.tokens.TOKEN;
 /**
  * A regex capture group "(...)"
  */
-public class CaptureGroup extends Unary implements Expression {
+public class CaptureGroup extends Unary {
 
     public CaptureGroup(Expression expression) {
         super(expression);

--- a/src/main/java/com/github/sgreben/regex_builder/CharClass.java
+++ b/src/main/java/com/github/sgreben/regex_builder/CharClass.java
@@ -133,6 +133,8 @@ public abstract class CharClass {
 
     public abstract void accept(CharClassVisitor visitor);
 
+    public abstract CharClass complement();
+
     public abstract void compile(java.util.List<TOKEN> output);
 
     public static class Posix {

--- a/src/main/java/com/github/sgreben/regex_builder/Pattern.java
+++ b/src/main/java/com/github/sgreben/regex_builder/Pattern.java
@@ -5,46 +5,49 @@ import com.github.sgreben.regex_builder.compiler.Compiler;
 public class Pattern {
 	private final java.util.regex.Pattern rawPattern;
 	private final CaptureGroupIndex groupIndex;
-	
+
 	public static Pattern compile(Expression expression) {
 		return Compiler.compile(expression);
 	}
-	
+
+	public static Pattern compile(Expression expression, int flags) {
+		return Compiler.compile(expression, flags);
+	}
+
 	public static Pattern quote(String literal) {
 		return Compiler.compile(Re.string(literal));
 	}
-	
-	public Pattern(java.util.regex.Pattern rawPattern, 
-				   CaptureGroupIndex groupIndex) {
+
+	public Pattern(java.util.regex.Pattern rawPattern, CaptureGroupIndex groupIndex) {
 		this.rawPattern = rawPattern;
 		this.groupIndex = groupIndex;
 	}
-	
+
 	public Matcher matcher(CharSequence input) {
 		java.util.regex.Matcher matcher = rawPattern.matcher(input);
 		return new Matcher(matcher, groupIndex);
 	}
-	
+
 	public static boolean matches(Expression regex, CharSequence input) {
 		return compile(regex).matcher(input).matches();
 	}
-	
+
 	public String[] split(CharSequence input) {
 		return rawPattern.split(input);
 	}
-	
+
 	public String[] split(CharSequence input, int limit) {
 		return rawPattern.split(input, limit);
 	}
-	
+
 	public java.util.stream.Stream<String> splitAsStream(CharSequence input) {
 		return rawPattern.splitAsStream(input);
 	}
-	
+
 	public String pattern() {
 		return rawPattern.pattern();
 	}
-	
+
 	@Override
 	public String toString() {
 		return rawPattern.toString();

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/AnyCharacter.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/AnyCharacter.java
@@ -1,9 +1,14 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.DOT;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class AnyCharacter extends Nullary {
+    public CharClass complement() {
+		return oneOf("");
+	}
+
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new DOT());
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/AnyCharacter.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/AnyCharacter.java
@@ -5,10 +5,12 @@ import com.github.sgreben.regex_builder.tokens.DOT;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class AnyCharacter extends Nullary {
-    public CharClass complement() {
+	@Override
+	public CharClass complement() {
 		return oneOf("");
 	}
 
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new DOT());
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/BeginInput.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/BeginInput.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class BeginInput extends Nullary {
 	public BeginInput() {}
+	public CharClass complement() { return new RawComplement(this); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\A"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/BeginInput.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/BeginInput.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class BeginInput extends Nullary {
-	public BeginInput() {}
-	public CharClass complement() { return new RawComplement(this); }
+	public BeginInput() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new RawComplement(this);
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\A"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Binary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Binary.java
@@ -1,22 +1,21 @@
 package com.github.sgreben.regex_builder.charclass;
 
-import com.github.sgreben.regex_builder.CharClass;
-
-import java.util.List;
-import java.util.LinkedList;
-import java.lang.Iterable;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import com.github.sgreben.regex_builder.CharClass;
 
 abstract class Binary extends CharClassBase {
 	private final List<CharClass> children;
-	
+
 	public Binary(CharClass leftChild, CharClass rightChild) {
 		List<CharClass> children = new LinkedList<CharClass>();
 		children.add(leftChild);
 		children.add(rightChild);
 		this.children = Collections.unmodifiableList(children);
 	}
-	
+
+	@Override
 	public Iterable<CharClass> children() {
 		return children;
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/CharClassBase.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/CharClassBase.java
@@ -3,9 +3,10 @@ package com.github.sgreben.regex_builder.charclass;
 import com.github.sgreben.regex_builder.CharClass;
 
 public abstract class CharClassBase extends CharClass {
+	@Override
 	public void accept(CharClassVisitor visitor) {
 		visitor.visitPre(this);
-		for(CharClass child : children ()) {
+		for (CharClass child : children()) {
 			child.accept(visitor);
 		}
 		visitor.visitPost(this);

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Complement.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Complement.java
@@ -1,19 +1,16 @@
 package com.github.sgreben.regex_builder.charclass;
 
-import com.github.sgreben.regex_builder.tokens.CARET;
-import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
-import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
-import com.github.sgreben.regex_builder.tokens.TOKEN;
 import com.github.sgreben.regex_builder.CharClass;
+import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Complement extends Unary {
-	public Complement(CharClass child) { super(child); }
-	public void compile(java.util.List<TOKEN> output) {
-		output.add(new START_CHAR_CLASS());
-		output.add(new CARET());
-		for(CharClass child : children()) {
-			child.compile(output);
-		}
-		output.add(new END_CHAR_CLASS());
+	final CharClass child;
+	public Complement(final CharClass child) {
+		super(child);
+		this.child = child;
+	}
+	public CharClass complement() { return child; }
+	public void compile(final java.util.List<TOKEN> output) {
+		child.complement().compile(output);
 	}
 }

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Complement.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Complement.java
@@ -5,11 +5,18 @@ import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Complement extends Unary {
 	final CharClass child;
+
 	public Complement(final CharClass child) {
 		super(child);
 		this.child = child;
 	}
-	public CharClass complement() { return child; }
+
+	@Override
+	public CharClass complement() {
+		return child;
+	}
+
+	@Override
 	public void compile(final java.util.List<TOKEN> output) {
 		child.complement().compile(output);
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Digit.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Digit.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Digit extends Nullary {
 	public Digit() {}
+	public CharClass complement() { return new NonDigit(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\d"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Digit.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Digit.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Digit extends Nullary {
-	public Digit() {}
-	public CharClass complement() { return new NonDigit(); }
+	public Digit() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new NonDigit();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\d"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/EndInput.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/EndInput.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class EndInput extends Nullary {
 	public EndInput() {}
+	public CharClass complement() { return new RawComplement(this); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\z"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/EndInput.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/EndInput.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class EndInput extends Nullary {
-	public EndInput() {}
-	public CharClass complement() { return new RawComplement(this); }
+	public EndInput() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new RawComplement(this);
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\z"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/EndInputBeforeFinalTerminator.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/EndInputBeforeFinalTerminator.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class EndInputBeforeFinalTerminator extends Nullary {
 	public EndInputBeforeFinalTerminator() {}
+	public CharClass complement() { return new RawComplement(this); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\z"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/EndInputBeforeFinalTerminator.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/EndInputBeforeFinalTerminator.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class EndInputBeforeFinalTerminator extends Nullary {
-	public EndInputBeforeFinalTerminator() {}
-	public CharClass complement() { return new RawComplement(this); }
+	public EndInputBeforeFinalTerminator() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new RawComplement(this);
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\z"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/HorizontalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/HorizontalWhitespace.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class HorizontalWhitespace extends Nullary {
 	public HorizontalWhitespace() {}
+	public CharClass complement() { return new NonHorizontalWhitespace(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\h"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/HorizontalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/HorizontalWhitespace.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class HorizontalWhitespace extends Nullary {
-	public HorizontalWhitespace() {}
-	public CharClass complement() { return new NonHorizontalWhitespace(); }
+	public HorizontalWhitespace() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new NonHorizontalWhitespace();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\h"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Intersection.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Intersection.java
@@ -1,5 +1,8 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.CHAR_CLASS_INTERSECTION;
 import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
@@ -7,13 +10,23 @@ import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Intersection extends Nary {
-	public Intersection(CharClass... children) { super(children); }
+	public Intersection(CharClass... children) {
+		super(children);
+	}
+
+	public CharClass complement() {
+		final List<CharClass> children = new ArrayList<>();
+		for (CharClass child : this.children()) {
+			children.add(child.complement());
+		}
+		return new Union(children.toArray(new CharClass[children.size()]));
+	}
 
 	public void compile(java.util.List<TOKEN> output) {
 		boolean first = true;
 		output.add(new START_CHAR_CLASS());
-		for(CharClass child : children()) {
-			if(!first) {
+		for (CharClass child : children()) {
+			if (!first) {
 				output.add(new CHAR_CLASS_INTERSECTION());
 			}
 			first = false;

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Intersection.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Intersection.java
@@ -2,7 +2,6 @@ package com.github.sgreben.regex_builder.charclass;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.CHAR_CLASS_INTERSECTION;
 import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
@@ -14,14 +13,16 @@ public class Intersection extends Nary {
 		super(children);
 	}
 
+	@Override
 	public CharClass complement() {
-		final List<CharClass> children = new ArrayList<>();
+		final List<CharClass> newChildren = new ArrayList<>();
 		for (CharClass child : this.children()) {
-			children.add(child.complement());
+			newChildren.add(child.complement());
 		}
-		return new Union(children.toArray(new CharClass[children.size()]));
+		return new Union(newChildren.toArray(new CharClass[newChildren.size()]));
 	}
 
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		boolean first = true;
 		output.add(new START_CHAR_CLASS());

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Java.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Java.java
@@ -1,5 +1,6 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.CHAR_CLASS_NAMED;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
@@ -10,6 +11,8 @@ import java.util.List;
  */
 public class Java extends Nullary {
     private final String name;
+
+    public CharClass complement() { return new RawComplement(this); }
 
     public Java(String name) {
         this.name = name;

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Java.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Java.java
@@ -1,10 +1,9 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import java.util.List;
 import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.CHAR_CLASS_NAMED;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
-
-import java.util.List;
 
 /**
  * Created by Sergey on 04.10.2016.
@@ -12,10 +11,13 @@ import java.util.List;
 public class Java extends Nullary {
     private final String name;
 
-    public CharClass complement() { return new RawComplement(this); }
-
     public Java(String name) {
         this.name = name;
+    }
+
+    @Override
+    public CharClass complement() {
+        return new RawComplement(this);
     }
 
     @Override

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Nary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Nary.java
@@ -8,13 +8,13 @@ import java.util.Collections;
 
 abstract class Nary extends CharClassBase {
 	private final List<CharClass> children;
-	
+
 	public Nary(final CharClass... childrenArray) {
 		this.children = Collections.unmodifiableList(
 			Arrays.asList(childrenArray)
 		);
 	}
-	
+
 	public Iterable<CharClass> children() {
 		return children;
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Nary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Nary.java
@@ -1,20 +1,18 @@
 package com.github.sgreben.regex_builder.charclass;
 
-import com.github.sgreben.regex_builder.CharClass;
-import java.util.List;
 import java.util.Arrays;
-import java.lang.Iterable;
 import java.util.Collections;
+import java.util.List;
+import com.github.sgreben.regex_builder.CharClass;
 
 abstract class Nary extends CharClassBase {
 	private final List<CharClass> children;
 
 	public Nary(final CharClass... childrenArray) {
-		this.children = Collections.unmodifiableList(
-			Arrays.asList(childrenArray)
-		);
+		this.children = Collections.unmodifiableList(Arrays.asList(childrenArray));
 	}
 
+	@Override
 	public Iterable<CharClass> children() {
 		return children;
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonDigit.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonDigit.java
@@ -5,9 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonDigit extends Nullary {
-	public NonDigit() {}
+	public NonDigit() {
+	}
 
-	public CharClass complement() { return new Digit(); }
+	@Override
+	public CharClass complement() {
+		return new Digit();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\D"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonDigit.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonDigit.java
@@ -1,10 +1,13 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonDigit extends Nullary {
 	public NonDigit() {}
+
+	public CharClass complement() { return new Digit(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\D"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonHorizontalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonHorizontalWhitespace.java
@@ -5,9 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonHorizontalWhitespace extends Nullary {
-	public NonHorizontalWhitespace() {}
+	public NonHorizontalWhitespace() {
+	}
 
-	public CharClass complement() { return new HorizontalWhitespace(); }
+	@Override
+	public CharClass complement() {
+		return new HorizontalWhitespace();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\H"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonHorizontalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonHorizontalWhitespace.java
@@ -1,10 +1,13 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonHorizontalWhitespace extends Nullary {
 	public NonHorizontalWhitespace() {}
+
+	public CharClass complement() { return new HorizontalWhitespace(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\H"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonVerticalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonVerticalWhitespace.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonVerticalWhitespace extends Nullary {
-	public NonVerticalWhitespace() {}
-	public CharClass complement() { return new VerticalWhitespace(); }
+	public NonVerticalWhitespace() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new VerticalWhitespace();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\V"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonVerticalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonVerticalWhitespace.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonVerticalWhitespace extends Nullary {
 	public NonVerticalWhitespace() {}
+	public CharClass complement() { return new VerticalWhitespace(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\V"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonWhitespace.java
@@ -5,9 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonWhitespace extends Nullary {
-	public NonWhitespace() {}
+	public NonWhitespace() {
+	}
 
-	public CharClass complement() { return new Whitespace(); }
+	@Override
+	public CharClass complement() {
+		return new Whitespace();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\S"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonWhitespace.java
@@ -1,10 +1,13 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonWhitespace extends Nullary {
 	public NonWhitespace() {}
+
+	public CharClass complement() { return new Whitespace(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\S"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordBoundary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordBoundary.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonWordBoundary extends Nullary {
-	public NonWordBoundary() {}
-	public CharClass complement() { return new WordBoundary(); }
+	public NonWordBoundary() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new WordBoundary();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\B"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordBoundary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordBoundary.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonWordBoundary extends Nullary {
 	public NonWordBoundary() {}
+	public CharClass complement() { return new WordBoundary(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\B"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordCharacter.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordCharacter.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonWordCharacter extends Nullary {
-	public NonWordCharacter() {}
-	public CharClass complement() { return new WordCharacter(); }
+	public NonWordCharacter() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new WordCharacter();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\W"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordCharacter.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NonWordCharacter.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NonWordCharacter extends Nullary {
 	public NonWordCharacter() {}
+	public CharClass complement() { return new WordCharacter(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\W"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/NoneOf.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/NoneOf.java
@@ -9,10 +9,17 @@ import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class NoneOf extends Nullary {
 	private final String chars;
+
 	public NoneOf(String chars) {
 		this.chars = chars;
 	}
-	public CharClass complement() { return new OneOf(chars); }
+
+	@Override
+	public CharClass complement() {
+		return new OneOf(chars);
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
 		output.add(new CARET());

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Nullary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Nullary.java
@@ -1,18 +1,18 @@
 package com.github.sgreben.regex_builder.charclass;
 
-import java.util.List;
-import java.util.LinkedList;
-import java.lang.Iterable;
 import java.util.Collections;
-
+import java.util.LinkedList;
+import java.util.List;
 import com.github.sgreben.regex_builder.CharClass;
 
 abstract class Nullary extends CharClassBase {
 	private static final List<CharClass> empty =
-		Collections.unmodifiableList(new LinkedList<CharClass>());
-	
-	public Nullary() {}
-	
+			Collections.unmodifiableList(new LinkedList<CharClass>());
+
+	public Nullary() {
+	}
+
+	@Override
 	public Iterable<CharClass> children() {
 		return empty;
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/OneOf.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/OneOf.java
@@ -8,10 +8,17 @@ import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class OneOf extends Nullary {
 	private final String chars;
+
 	public OneOf(String chars) {
 		this.chars = chars;
 	}
-	public CharClass complement() { return new NoneOf(chars); }
+
+	@Override
+	public CharClass complement() {
+		return new NoneOf(chars);
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
 		output.add(new RAW(chars));

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/OneOf.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/OneOf.java
@@ -1,5 +1,6 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
@@ -10,6 +11,7 @@ public class OneOf extends Nullary {
 	public OneOf(String chars) {
 		this.chars = chars;
 	}
+	public CharClass complement() { return new NoneOf(chars); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
 		output.add(new RAW(chars));

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Posix.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Posix.java
@@ -1,5 +1,6 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.CHAR_CLASS_NAMED;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
@@ -10,6 +11,9 @@ public class Posix extends Nullary {
     public Posix(String name) {
         this.name = name;
     }
+
+    @Override
+    public CharClass complement() { return new RawComplement(this); }
 
     @Override
     public void compile(List<TOKEN> output) {

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/RangeComplement.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/RangeComplement.java
@@ -1,25 +1,33 @@
 package com.github.sgreben.regex_builder.charclass;
 
 import com.github.sgreben.regex_builder.CharClass;
-import com.github.sgreben.regex_builder.tokens.*;
+import com.github.sgreben.regex_builder.tokens.CARET;
+import com.github.sgreben.regex_builder.tokens.DASH;
+import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
+import com.github.sgreben.regex_builder.tokens.RAW;
+import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
+import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class RangeComplement extends Nullary {
 	private final char[] range;
+
 	public RangeComplement(char... range) {
 		this.range = range;
 	}
 
 	@Override
-	public CharClass complement() { return new RawComplement(this); }
+	public CharClass complement() {
+		return new Range(range);
+	}
 
 	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
 		output.add(new CARET());
-		for(int i = 0; i < range.length; i += 2) {
-			output.add(new RAW(""+range[i]));
+		for (int i = 0; i < range.length; i += 2) {
+			output.add(new RAW("" + range[i]));
 			output.add(new DASH());
-			output.add(new RAW(""+range[i+1]));
+			output.add(new RAW("" + range[i + 1]));
 
 		}
 		output.add(new END_CHAR_CLASS());

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/RangeComplement.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/RangeComplement.java
@@ -3,18 +3,19 @@ package com.github.sgreben.regex_builder.charclass;
 import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.*;
 
-public class Range extends Nullary {
+public class RangeComplement extends Nullary {
 	private final char[] range;
-	public Range(char... range) {
+	public RangeComplement(char... range) {
 		this.range = range;
 	}
 
 	@Override
-	public CharClass complement() { return new RangeComplement(range); }
+	public CharClass complement() { return new RawComplement(this); }
 
 	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
+		output.add(new CARET());
 		for(int i = 0; i < range.length; i += 2) {
 			output.add(new RAW(""+range[i]));
 			output.add(new DASH());

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/RawComplement.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/RawComplement.java
@@ -1,22 +1,24 @@
 package com.github.sgreben.regex_builder.charclass;
 
-import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.CARET;
 import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
-import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
+import com.github.sgreben.regex_builder.CharClass;
 
-public class NoneOf extends Nullary {
-	private final String chars;
-	public NoneOf(String chars) {
-		this.chars = chars;
+class RawComplement extends Unary {
+	final CharClass child;
+	public RawComplement(final CharClass child) {
+		super(child);
+		this.child = child;
 	}
-	public CharClass complement() { return new OneOf(chars); }
-	public void compile(java.util.List<TOKEN> output) {
+	public CharClass complement() { return child; }
+	public void compile(final java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
 		output.add(new CARET());
-		output.add(new RAW(chars));
+		for(final CharClass child : children()) {
+			child.compile(output);
+		}
 		output.add(new END_CHAR_CLASS());
 	}
 }

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/RawComplement.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/RawComplement.java
@@ -1,22 +1,29 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.CARET;
 import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
-import com.github.sgreben.regex_builder.CharClass;
 
 class RawComplement extends Unary {
 	final CharClass child;
+
 	public RawComplement(final CharClass child) {
 		super(child);
 		this.child = child;
 	}
-	public CharClass complement() { return child; }
+
+	@Override
+	public CharClass complement() {
+		return child;
+	}
+
+	@Override
 	public void compile(final java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
 		output.add(new CARET());
-		for(final CharClass child : children()) {
+		for (final CharClass child : children()) {
 			child.compile(output);
 		}
 		output.add(new END_CHAR_CLASS());

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Unary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Unary.java
@@ -1,20 +1,20 @@
 package com.github.sgreben.regex_builder.charclass;
 
-import java.util.List;
-import java.util.LinkedList;
-import java.lang.Iterable;
 import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 import com.github.sgreben.regex_builder.CharClass;
 
 public abstract class Unary extends CharClassBase {
 	private final List<CharClass> children;
-	
+
 	public Unary(CharClass child) {
 		List<CharClass> children = new LinkedList<CharClass>();
 		children.add(child);
 		this.children = Collections.unmodifiableList(children);
 	}
-	
+
+	@Override
 	public Iterable<CharClass> children() {
 		return children;
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Union.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Union.java
@@ -2,15 +2,17 @@ package com.github.sgreben.regex_builder.charclass;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Union extends Nary {
-	public Union(CharClass... children) { super(children); }
+	public Union(CharClass... children) {
+		super(children);
+	}
 
+	@Override
 	public CharClass complement() {
 		final List<CharClass> children = new ArrayList<>();
 		for (CharClass child : this.children()) {
@@ -19,9 +21,10 @@ public class Union extends Nary {
 		return new Intersection(children.toArray(new CharClass[children.size()]));
 	}
 
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());
-		for(CharClass child : children()) {
+		for (CharClass child : children()) {
 			child.compile(output);
 		}
 		output.add(new END_CHAR_CLASS());

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Union.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Union.java
@@ -1,5 +1,8 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.END_CHAR_CLASS;
 import com.github.sgreben.regex_builder.tokens.START_CHAR_CLASS;
@@ -7,6 +10,14 @@ import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Union extends Nary {
 	public Union(CharClass... children) { super(children); }
+
+	public CharClass complement() {
+		final List<CharClass> children = new ArrayList<>();
+		for (CharClass child : this.children()) {
+			children.add(child.complement());
+		}
+		return new Intersection(children.toArray(new CharClass[children.size()]));
+	}
 
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new START_CHAR_CLASS());

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/VerticalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/VerticalWhitespace.java
@@ -5,10 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class VerticalWhitespace extends Nullary {
-	public VerticalWhitespace() {}
+	public VerticalWhitespace() {
+	}
 
-	public CharClass complement() { return new NonVerticalWhitespace(); }
+	@Override
+	public CharClass complement() {
+		return new NonVerticalWhitespace();
+	}
 
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\v"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/VerticalWhitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/VerticalWhitespace.java
@@ -1,10 +1,14 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class VerticalWhitespace extends Nullary {
 	public VerticalWhitespace() {}
+
+	public CharClass complement() { return new NonVerticalWhitespace(); }
+
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\v"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Whitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Whitespace.java
@@ -1,10 +1,14 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Whitespace extends Nullary {
 	public Whitespace() {}
+
+	public CharClass complement() { return new NonWhitespace(); }
+
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\s"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/Whitespace.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/Whitespace.java
@@ -5,10 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Whitespace extends Nullary {
-	public Whitespace() {}
+	public Whitespace() {
+	}
 
-	public CharClass complement() { return new NonWhitespace(); }
+	@Override
+	public CharClass complement() {
+		return new NonWhitespace();
+	}
 
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\s"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/WordBoundary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/WordBoundary.java
@@ -1,10 +1,14 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class WordBoundary extends Nullary {
 	public WordBoundary() {}
+
+	public CharClass complement() { return new NonWordBoundary(); }
+
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\b"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/WordBoundary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/WordBoundary.java
@@ -5,10 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class WordBoundary extends Nullary {
-	public WordBoundary() {}
+	public WordBoundary() {
+	}
 
-	public CharClass complement() { return new NonWordBoundary(); }
+	@Override
+	public CharClass complement() {
+		return new NonWordBoundary();
+	}
 
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\b"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/WordCharacter.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/WordCharacter.java
@@ -5,8 +5,15 @@ import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class WordCharacter extends Nullary {
-	public WordCharacter() {}
-	public CharClass complement() { return new NonWordCharacter(); }
+	public WordCharacter() {
+	}
+
+	@Override
+	public CharClass complement() {
+		return new NonWordCharacter();
+	}
+
+	@Override
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\w"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/charclass/WordCharacter.java
+++ b/src/main/java/com/github/sgreben/regex_builder/charclass/WordCharacter.java
@@ -1,10 +1,12 @@
 package com.github.sgreben.regex_builder.charclass;
 
+import com.github.sgreben.regex_builder.CharClass;
 import com.github.sgreben.regex_builder.tokens.RAW;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class WordCharacter extends Nullary {
 	public WordCharacter() {}
+	public CharClass complement() { return new NonWordCharacter(); }
 	public void compile(java.util.List<TOKEN> output) {
 		output.add(new RAW("\\w"));
 	}

--- a/src/main/java/com/github/sgreben/regex_builder/compiler/Compiler.java
+++ b/src/main/java/com/github/sgreben/regex_builder/compiler/Compiler.java
@@ -1,15 +1,18 @@
 package com.github.sgreben.regex_builder.compiler;
 
 import java.util.LinkedList;
-
 import com.github.sgreben.regex_builder.CaptureGroup;
 import com.github.sgreben.regex_builder.CaptureGroupIndex;
-import com.github.sgreben.regex_builder.Pattern;
 import com.github.sgreben.regex_builder.Expression;
+import com.github.sgreben.regex_builder.Pattern;
 import com.github.sgreben.regex_builder.tokens.TOKEN;
 
 public class Compiler {
 	public static Pattern compile(Expression expression) {
+		return compile(expression, 0);
+	}
+
+	public static Pattern compile(Expression expression, final int flags) {
 		CaptureGroupVisitor visitor = new CaptureGroupVisitor();
 		CaptureGroup entireMatch = new CaptureGroup(expression);
 		LinkedList<TOKEN> tokens = new LinkedList<TOKEN>();
@@ -17,12 +20,12 @@ public class Compiler {
 		entireMatch.accept(visitor);
 		CaptureGroupIndex index = visitor.get();
 		entireMatch.compile(index, tokens);
-		for(TOKEN op : tokens) {
+		for (TOKEN op : tokens) {
 			sb.append(op.regexString());
 		}
 		String regexString = sb.toString();
-		java.util.regex.Pattern rawPattern = java.util.regex.Pattern.compile(regexString);
+		java.util.regex.Pattern rawPattern = java.util.regex.Pattern.compile(regexString, flags);
 		return new Pattern(rawPattern, index);
 	}
-	
+
 }

--- a/src/main/java/com/github/sgreben/regex_builder/expression/Binary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/expression/Binary.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-abstract class Binary extends ExpressionBase implements Expression {
+abstract class Binary extends ExpressionBase {
     private final List<Expression> children;
 
     public Binary(Expression leftChild, Expression rightChild) {

--- a/src/main/java/com/github/sgreben/regex_builder/expression/Nary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/expression/Nary.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-abstract class Nary extends ExpressionBase implements Expression {
+abstract class Nary extends ExpressionBase {
     private final List<Expression> children;
 
     public Nary(final Expression... childrenArray) {

--- a/src/main/java/com/github/sgreben/regex_builder/expression/Nullary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/expression/Nullary.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-abstract class Nullary extends ExpressionBase implements Expression {
+abstract class Nullary extends ExpressionBase {
     private static final List<Expression> empty =
             Collections.unmodifiableList(new LinkedList<Expression>());
 

--- a/src/main/java/com/github/sgreben/regex_builder/expression/Unary.java
+++ b/src/main/java/com/github/sgreben/regex_builder/expression/Unary.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 
-public abstract class Unary extends ExpressionBase implements Expression {
+public abstract class Unary extends ExpressionBase {
     private final Expression child;
     private final List<Expression> children;
 

--- a/src/main/java/com/github/sgreben/regex_builder/tokens/CHAR_CLASS_NAMED.java
+++ b/src/main/java/com/github/sgreben/regex_builder/tokens/CHAR_CLASS_NAMED.java
@@ -1,11 +1,9 @@
 package com.github.sgreben.regex_builder.tokens;
 
 public class CHAR_CLASS_NAMED implements TOKEN {
-    private final String name;
     private final String regexString;
 
     public CHAR_CLASS_NAMED(String name) {
-        this.name = name;
         this.regexString = "\\p{"+name+"}";
     }
 

--- a/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
+++ b/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
@@ -2,7 +2,6 @@ package com.github.sgreben.regex_builder;
 
 import static org.junit.Assert.assertThat;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static com.github.sgreben.regex_builder.hamcrest.MatchesPattern.*;
@@ -24,12 +23,11 @@ public class CharClassTest {
 		assertCharClassMismatch(hexDigit(), "]");
 	}
 
-	@Ignore
 	@Test
 	public void testNonHexDigit() throws Exception {
 		assertCharClassMismatch(nonHexDigit(), "0123456789");
 		assertCharClassMismatch(nonHexDigit(), "abcdef");
-		assertCharClassMatch(nonHexDigit(), "ABCDEF");
+		assertCharClassMismatch(nonHexDigit(), "ABCDEF");
 
 		assertCharClassMatch(nonHexDigit(), "G");
 		assertCharClassMatch(nonHexDigit(), "[");

--- a/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
+++ b/src/test/java/com/github/sgreben/regex_builder/CharClassTest.java
@@ -1,14 +1,16 @@
 package com.github.sgreben.regex_builder;
 
+import static com.github.sgreben.regex_builder.CharClass.complement;
+import static com.github.sgreben.regex_builder.CharClass.hexDigit;
+import static com.github.sgreben.regex_builder.CharClass.nonHexDigit;
+import static com.github.sgreben.regex_builder.CharClass.noneOf;
+import static com.github.sgreben.regex_builder.CharClass.oneOf;
+import static com.github.sgreben.regex_builder.CharClass.whitespaceChar;
+import static com.github.sgreben.regex_builder.Re.repeat;
+import static com.github.sgreben.regex_builder.hamcrest.MatchesPattern.matchesPattern;
+import static org.hamcrest.CoreMatchers.not;
 import static org.junit.Assert.assertThat;
-
 import org.junit.Test;
-
-import static com.github.sgreben.regex_builder.hamcrest.MatchesPattern.*;
-import static com.github.sgreben.regex_builder.Re.*;
-import static com.github.sgreben.regex_builder.CharClass.*;
-
-import static org.hamcrest.CoreMatchers.*;
 
 public class CharClassTest {
 
@@ -32,6 +34,18 @@ public class CharClassTest {
 		assertCharClassMatch(nonHexDigit(), "G");
 		assertCharClassMatch(nonHexDigit(), "[");
 		assertCharClassMatch(nonHexDigit(), "]");
+	}
+
+	@Test
+	public void testComplement() throws Exception {
+		assertCharClassMismatch(complement(oneOf("abc")), "abc");
+		assertCharClassMatch(complement(oneOf("abc")), "xyz");
+
+		assertCharClassMismatch(complement(whitespaceChar()), "  ");
+		assertCharClassMatch(complement(whitespaceChar()), "123");
+
+		assertCharClassMismatch(complement(oneOf("bc")), "bcbc");
+		assertCharClassMatch(complement(complement(oneOf("bc"))), "bcbc");
 	}
 
 	@Test

--- a/src/test/java/com/github/sgreben/regex_builder/MatcherTest.java
+++ b/src/test/java/com/github/sgreben/regex_builder/MatcherTest.java
@@ -1,7 +1,14 @@
 package com.github.sgreben.regex_builder;
 
-import static org.junit.Assert.*;
-import static com.github.sgreben.regex_builder.Re.*;
+import static com.github.sgreben.regex_builder.Re.capture;
+import static com.github.sgreben.regex_builder.Re.repeat;
+import static com.github.sgreben.regex_builder.Re.repeat1;
+import static com.github.sgreben.regex_builder.Re.replacement;
+import static com.github.sgreben.regex_builder.Re.sequence;
+import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 public class MatcherTest {
@@ -12,13 +19,13 @@ public class MatcherTest {
 		Matcher m = p.matcher(s);
 		assertTrue(m.matches());
 	}
-	
+
 	@Test
 	public void matchNumber_matchedIsTrue_static() {
 		String s = "123";
 		assertTrue(Pattern.matches(Re.number(), s));
 	}
-	
+
 	@Test
 	public void matchNumber_matchedIsFalse_static() {
 		String s = "abc";
@@ -29,11 +36,7 @@ public class MatcherTest {
 	public void matchAnyNumberAny_matchedIsTrue() {
 		String s = "abc 123 def";
 		Expression nonNumbers = Re.repeat(CharClass.nonDigit());
-		Pattern p = Pattern.compile(Re.sequence(
-			nonNumbers,
-			Re.number(),
-			nonNumbers
-		));
+		Pattern p = Pattern.compile(Re.sequence(nonNumbers, Re.number(), nonNumbers));
 		Matcher m = p.matcher(s);
 		assertTrue(m.matches());
 	}
@@ -53,11 +56,7 @@ public class MatcherTest {
 		String s = "abc 123 def";
 		CaptureGroup number = Re.capture(Re.number());
 		Expression nonNumbers = Re.repeat(CharClass.nonDigit());
-		Pattern p = Pattern.compile(Re.sequence(
-			nonNumbers,
-			number,
-			nonNumbers
-		));
+		Pattern p = Pattern.compile(Re.sequence(nonNumbers, number, nonNumbers));
 		Matcher m = p.matcher(s);
 		m.matches();
 		assertEquals("123", m.group(number));
@@ -67,12 +66,7 @@ public class MatcherTest {
 	public void matchNumbers_separatedBySpaces() {
 		String s = "123 456 789";
 		CaptureGroup number = Re.capture(Re.number());
-		Pattern p = Pattern.compile(
-			Re.sequence(
-				number,
-				Re.optional(Re.whitespace())
-			)
-		);
+		Pattern p = Pattern.compile(Re.sequence(number, Re.optional(Re.whitespace())));
 		Matcher m = p.matcher(s);
 		m.find();
 		assertEquals("123", m.group(number));
@@ -81,19 +75,14 @@ public class MatcherTest {
 		m.find();
 		assertEquals("789", m.group(number));
 	}
-	
+
 	@Test
 	public void matchNumbers_replaceByParenthesized() {
 		String s = "123 456 789";
 		CaptureGroup number = Re.capture(Re.number());
-		Pattern p = Pattern.compile(
-			Re.sequence(
-				number,
-				Re.optional(Re.whitespace())
-			)
-		);
+		Pattern p = Pattern.compile(Re.sequence(number, Re.optional(Re.whitespace())));
 		Matcher m = p.matcher(s);
-		String result = m.replaceAll(Re.replacement("(number ",number,")"));
+		String result = m.replaceAll(Re.replacement("(number ", number, ")"));
 		assertEquals("(number 123)(number 456)(number 789)", result);
 	}
 
@@ -106,7 +95,7 @@ public class MatcherTest {
 		String result = m.replaceAll(Re.replacement(word, word));
 		assertEquals("abcabc defdef ghighi", result);
 	}
-	
+
 	@Test
 	public void matchChar_replaceByDoubled() {
 		String s = "abc def ghi";
@@ -116,7 +105,7 @@ public class MatcherTest {
 		String result = m.replaceAll(Re.replacement("<", b, b, ">"));
 		assertEquals("a<bb>c def ghi", result);
 	}
-	
+
 	@Test
 	public void matchChar_literalSyntaxString_replaceByDoubled() {
 		String s = "abc def ghi";
@@ -126,14 +115,13 @@ public class MatcherTest {
 		String result = m.replaceAll(Re.replacement("<", b, b, ">"));
 		assertEquals("a<bb>c def ghi", result);
 	}
-	
+
 	@Test
 	public void matchWithBackReference_capturesCorrectly() {
 		String s = "abc abc def";
 		CaptureGroup word = Re.capture(Re.word());
-		CaptureGroup sameWordTwice = Re.capture(
-			Re.sequence(word, Re.whitespace1(), Re.backReference(word))
-		);
+		CaptureGroup sameWordTwice =
+				Re.capture(Re.sequence(word, Re.whitespace1(), Re.backReference(word)));
 		Pattern p = Pattern.compile(sameWordTwice);
 		Matcher m = p.matcher(s);
 		m.find();
@@ -161,7 +149,18 @@ public class MatcherTest {
 		String result = m.replaceAll(Re.replacement("<", b, b, ">"));
 		assertEquals("<bb>c def ghi", result);
 	}
-	
+
+	@Test
+	public void matchCharTwoGroup_replaceByDoubled_caseInsensitive() {
+		String s = "abc ABC def ghi";
+		CaptureGroup a = Re.capture(Re.character('a'));
+		CaptureGroup b = Re.capture(Re.character('b'));
+		Pattern p = Pattern.compile(Re.sequence(a, b), CASE_INSENSITIVE);
+		Matcher m = p.matcher(s);
+		String result = m.replaceAll(Re.replacement("<", b, b, ">"));
+		assertEquals("<bb>c <BB>C def ghi", result);
+	}
+
 	@Test
 	public void matchChars_literalSyntax_replaceByDoubled() {
 		String s = "abc def ghi";
@@ -177,34 +176,24 @@ public class MatcherTest {
 	public void nestedCapture_returnsBoth() {
 		String s = "There are things. Things have properties.";
 		CaptureGroup word = Re.capture(Re.word());
-		CaptureGroup sentence = Re.capture(
-			Re.sequence(
-				Re.separatedBy(Re.whitespace(), word),
-				Re.character('.')
-			)
-		);
-		Pattern p = Pattern.compile(
-			Re.sequence(sentence, Re.optional(Re.whitespace()))
-		);
+		CaptureGroup sentence =
+				Re.capture(Re.sequence(Re.separatedBy(Re.whitespace(), word), Re.character('.')));
+		Pattern p = Pattern.compile(Re.sequence(sentence, Re.optional(Re.whitespace())));
 		Matcher m = p.matcher(s);
 		m.find();
 		assertEquals("There are things.", m.group(sentence));
 		m.find();
-		assertEquals("Things have properties.", m.group(sentence));	
+		assertEquals("Things have properties.", m.group(sentence));
 	}
-	
+
 	@Test
 	public void hexColorExampleFromReadme() {
-		Expression hexDigit = Re.charClass(CharClass.union(
-			CharClass.range('a','f'),
-			CharClass.range('A','F'),
-			CharClass.digit()
-		));
+		Expression hexDigit = Re.charClass(CharClass.union(CharClass.range('a', 'f'),
+				CharClass.range('A', 'F'), CharClass.digit()));
 		Expression threeHexDigits = Re.repeat(hexDigit, 3);
-		CaptureGroup hexValue = Re.capture(
-			threeHexDigits,              // #FFF  
-			Re.optional(threeHexDigits)  // #FFFFFF
-	    );
+		CaptureGroup hexValue = Re.capture(threeHexDigits, // #FFF
+				Re.optional(threeHexDigits) // #FFFFFF
+		);
 		Expression hexColor = Re.sequence('#', hexValue);
 		Pattern p = Pattern.compile(hexColor);
 		Matcher m = p.matcher("#0FAFF3 and #1bf");
@@ -213,16 +202,14 @@ public class MatcherTest {
 		m.find();
 		assertEquals("1bf", m.group(hexValue));
 	}
+
 	@Test
 	public void hexColorExampleFromReadme_alternativeBuild() {
-		Expression hexDigit = Re.charClass(CharClass.range(
-			'a','f', 'A','F', '0','9'
-		));
+		Expression hexDigit = Re.charClass(CharClass.range('a', 'f', 'A', 'F', '0', '9'));
 		Expression threeHexDigits = Re.repeat(hexDigit, 3);
-		CaptureGroup hexValue = Re.capture(Re.sequence(
-			threeHexDigits,              // #FFF  
-			Re.optional(threeHexDigits)  // #FFFFFF
-	    ));
+		CaptureGroup hexValue = Re.capture(Re.sequence(threeHexDigits, // #FFF
+				Re.optional(threeHexDigits) // #FFFFFF
+		));
 		Expression hexColor = Re.sequence('#', hexValue);
 		Pattern p = Pattern.compile(hexColor);
 		Matcher m = p.matcher("#0FAFF3 and #1bf");
@@ -231,13 +218,13 @@ public class MatcherTest {
 		m.find();
 		assertEquals("1bf", m.group(hexValue));
 	}
+
 	@Test
 	public void hexColorExampleFromReadme_alternativeBuildUsingBuiltinHexdigit() {
 		Expression threeHexDigits = Re.repeat(CharClass.hexDigit(), 3);
-		CaptureGroup hexValue = Re.capture(Re.sequence(
-			threeHexDigits,              // #FFF  
-			Re.optional(threeHexDigits)  // #FFFFFF
-	    ));
+		CaptureGroup hexValue = Re.capture(Re.sequence(threeHexDigits, // #FFF
+				Re.optional(threeHexDigits) // #FFFFFF
+		));
 		Expression hexColor = Re.sequence('#', hexValue);
 		Pattern p = Pattern.compile(hexColor);
 		Matcher m = p.matcher("#0FAFF3 and #1bf");
@@ -246,86 +233,75 @@ public class MatcherTest {
 		m.find();
 		assertEquals("1bf", m.group(hexValue));
 	}
+
 	@Test
 	public void possessiveQualifierTest() {
-		Expression xxy = Re.sequence(
-			Re.repeatPossessive(Re.sequence(
-				Re.repeatPossessive('x'),
-				Re.repeatPossessive('x')
-			)),
-			'y'
-		);
+		Expression xxy =
+				Re.sequence(
+						Re.repeatPossessive(
+								Re.sequence(Re.repeatPossessive('x'), Re.repeatPossessive('x'))),
+						'y');
 		Pattern p = Pattern.compile(xxy);
 		Matcher m = p.matcher("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx");
 		assertEquals(false, m.matches());
 	}
-	
+
 	@Test
 	public void possessiveQualifierTest_positive() {
 		Expression xxy = Re.sequence(
-			Re.repeat(Re.sequence(
-				Re.repeat('x').possessive(),
-				Re.repeat('x').possessive()
-			)).possessive(),
-			'y'
-		);
+				Re.repeat(Re.sequence(Re.repeat('x').possessive(), Re.repeat('x').possessive()))
+						.possessive(),
+				'y');
 		Pattern p = Pattern.compile(xxy);
 		Matcher m = p.matcher("xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxy");
 		assertEquals(true, m.matches());
 	}
-	
+
 	@Test
 	public void charClassIntersectionTest() {
-		Expression d = Re.charClass(CharClass.intersection(
-			CharClass.oneOf("abcd"),
-			CharClass.oneOf("defg"),
-			CharClass.wordChar()
-		));
+		Expression d = Re.charClass(CharClass.intersection(CharClass.oneOf("abcd"),
+				CharClass.oneOf("defg"), CharClass.wordChar()));
 		Pattern p = Pattern.compile(d);
 		Matcher m1 = p.matcher("a");
 		Matcher m2 = p.matcher("d");
 		assertFalse(m1.matches());
 		assertTrue(m2.matches());
-		
+
 	}
+
 	@Test
 	public void positiveLookaheadTest() {
-		Expression abc = Re.sequence(
-			"abc", Re.positiveLookahead("def")
-		);
+		Expression abc = Re.sequence("abc", Re.positiveLookahead("def"));
 		Pattern p = Pattern.compile(abc);
 		assertFalse(p.matcher("123abc").find());
 		assertTrue(p.matcher("123abcdef").find());
 		assertFalse(p.matcher("123abc123def").find());
 		assertTrue(p.matcher("abcdef123").find());
 	}
+
 	@Test
 	public void positiveLookbehindTest() {
-		Expression abc = Re.sequence(
-			Re.positiveLookbehind("def"), "abc"
-		);
+		Expression abc = Re.sequence(Re.positiveLookbehind("def"), "abc");
 		Pattern p = Pattern.compile(abc);
 		assertFalse(p.matcher("def123abc").find());
 		assertTrue(p.matcher("123defabc").find());
 		assertFalse(p.matcher("def123abc123def").find());
 		assertTrue(p.matcher("defabc123").find());
 	}
+
 	@Test
 	public void negativeLookbehindTest() {
-		Expression abc = Re.sequence(
-			Re.negativeLookbehind("def"), "abc"
-		);
+		Expression abc = Re.sequence(Re.negativeLookbehind("def"), "abc");
 		Pattern p = Pattern.compile(abc);
 		assertTrue(p.matcher("def123abc").find());
 		assertFalse(p.matcher("123defabc").find());
 		assertTrue(p.matcher("def123abc123def").find());
 		assertFalse(p.matcher("defabc123").find());
 	}
+
 	@Test
 	public void negativeLookaheadTest() {
-		Expression abc = Re.sequence(
-			"abc", Re.negativeLookahead("def")
-		);
+		Expression abc = Re.sequence("abc", Re.negativeLookahead("def"));
 		Pattern p = Pattern.compile(abc);
 		assertTrue(p.matcher("123abc").find());
 		assertFalse(p.matcher("123abcdef").find());
@@ -335,45 +311,45 @@ public class MatcherTest {
 
 	@Test
 	public void apacheLogLine() {
-		String logLine = "127.0.0.1 - - [21/Jul/2014:9:55:27 -0800] \"GET /home.html HTTP/1.1\" 200 2048";
-		// "^(\\S+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})\\] \"(\\S+) (\\S+) (\\S+)\" (\\d{3}) (\\d+)";
+		String logLine =
+				"127.0.0.1 - - [21/Jul/2014:9:55:27 -0800] \"GET /home.html HTTP/1.1\" 200 2048";
+		// "^(\\S+) (\\S+) (\\S+) \\[([\\w:/]+\\s[+\\-]\\d{4})\\] \"(\\S+) (\\S+) (\\S+)\" (\\d{3})
+		// (\\d+)";
 
-        CaptureGroup ip, client, user, dateTime, method, request, protocol, responseCode, size;
-        Expression nonWhitespace = repeat1(CharClass.nonWhitespaceChar());
+		CaptureGroup ip, client, user, dateTime, method, request, protocol, responseCode, size;
+		Expression nonWhitespace = repeat1(CharClass.nonWhitespaceChar());
 
-        ip = capture(nonWhitespace);
+		ip = capture(nonWhitespace);
 		client = capture(nonWhitespace);
 		user = capture(nonWhitespace);
-		dateTime = capture(sequence(
-				repeat1(CharClass.union(CharClass.wordChar(),':','/')),  // 21/Jul/2014:9:55:27
-				CharClass.whitespaceChar(),
-				CharClass.oneOf("+\\-"),     // -
+		dateTime = capture(sequence(repeat1(CharClass.union(CharClass.wordChar(), ':', '/')), // 21/Jul/2014:9:55:27
+				CharClass.whitespaceChar(), CharClass.oneOf("+\\-"), // -
 				repeat(CharClass.digit(), 4) // 0800
 		));
 		method = capture(nonWhitespace);
 		request = capture(nonWhitespace);
 		protocol = capture(nonWhitespace);
 		responseCode = capture(repeat(CharClass.digit(), 3));
-        size = capture(repeat1(CharClass.digit()));
+		size = capture(repeat1(CharClass.digit()));
 
-        Pattern p = Pattern.compile(sequence(
-                CharClass.beginInput(),
-                ip, ' ', client, ' ', user, " [", dateTime, "] \"", method, ' ', request, ' ', protocol, "\" ", responseCode, ' ', size,
-                CharClass.endInput()
-        ));
+		Pattern p = Pattern.compile(sequence(CharClass.beginInput(), ip, ' ', client, ' ', user,
+				" [", dateTime, "] \"", method, ' ', request, ' ', protocol, "\" ", responseCode,
+				' ', size, CharClass.endInput()));
 
-        Matcher m = p.matcher(logLine);
-        assertTrue(m.matches());
-        assertEquals("127.0.0.1", m.group(ip));
-        assertEquals("-", m.group(client));
-        assertEquals("-", m.group(user));
-        assertEquals("21/Jul/2014:9:55:27 -0800", m.group(dateTime));
-        assertEquals("GET", m.group(method));
-        assertEquals("/home.html", m.group(request));
-        assertEquals("HTTP/1.1", m.group(protocol));
-        assertEquals("200", m.group(responseCode));
-        assertEquals("2048", m.group(size));
-		assertEquals("127.0.0.1 - /home.html - 200", m.replaceAll(replacement(ip, " - ", request, " - ", responseCode)));
-		assertEquals("127.0.0.1 - /home.html - 200", m.replaceFirst(replacement(ip, " - ", request, " - ", responseCode)));
+		Matcher m = p.matcher(logLine);
+		assertTrue(m.matches());
+		assertEquals("127.0.0.1", m.group(ip));
+		assertEquals("-", m.group(client));
+		assertEquals("-", m.group(user));
+		assertEquals("21/Jul/2014:9:55:27 -0800", m.group(dateTime));
+		assertEquals("GET", m.group(method));
+		assertEquals("/home.html", m.group(request));
+		assertEquals("HTTP/1.1", m.group(protocol));
+		assertEquals("200", m.group(responseCode));
+		assertEquals("2048", m.group(size));
+		assertEquals("127.0.0.1 - /home.html - 200",
+				m.replaceAll(replacement(ip, " - ", request, " - ", responseCode)));
+		assertEquals("127.0.0.1 - /home.html - 200",
+				m.replaceFirst(replacement(ip, " - ", request, " - ", responseCode)));
 	}
 }


### PR DESCRIPTION
Fixes #5 and #8.

- The char class "compiler" is now complement aware (e.g. producing `\S` as the .complement() of `\s`)
- Added a `Pattern.compile(expression, flags)` method. The second argument is a java.util.regex.Pattern flag bitmask (such as [java.util.regex.Pattern.CASE_INSENSITIVE](https://docs.oracle.com/javase/7/docs/api/java/util/regex/Pattern.html#CASE_INSENSITIVE)).